### PR TITLE
collision for maze & fixed wall glitch

### DIFF
--- a/Config/DefaultEngine.ini
+++ b/Config/DefaultEngine.ini
@@ -197,6 +197,7 @@ AppliedDefaultGraphicsPerformance=Scalable
 [/Script/Engine.Engine]
 +ActiveGameNameRedirects=(OldGameName="TP_ThirdPersonBP",NewGameName="/Script/HarvestOfFear")
 +ActiveGameNameRedirects=(OldGameName="/Script/TP_ThirdPersonBP",NewGameName="/Script/HarvestOfFear")
+NearClipPlane=0.500000
 
 [/Script/AndroidFileServerEditor.AndroidFileServerRuntimeSettings]
 bEnablePlugin=True

--- a/Content/Geometry/Box_Brush_StaticMesh.uasset
+++ b/Content/Geometry/Box_Brush_StaticMesh.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1093fc59a8ea6d48d3816bdc15fe0fcc8d48326af4fc3d396d3cdd13c6435cdd
-size 248150
+oid sha256:95751d6bb6ca68c21d7fe298fa34907b144455118dd3d509f73f9fd9f40a697a
+size 248855

--- a/Content/Map1.umap
+++ b/Content/Map1.umap
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:40b240446084bc170a392da8f3e4a9b280c6616f6ef5312ce23cdda4c630cb26
-size 1930029
+oid sha256:bf4e8b9854320ee603dc8fe6bd488b37bc7a349f46834fa71680ca2c4bf15b53
+size 1930193


### PR DESCRIPTION
add collision to walls to stop player from walking through walls and fixed camera clipping