### PR TITLE
Adjusted pickupable key to have max stack of 1 in inventory.

### DIFF
--- a/Content/Map1.umap
+++ b/Content/Map1.umap
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:4c7ea3b814f159f4a707e1dd3f833d159dac61df11e2913bd5fffe7352c27b08
-size 39938458
+oid sha256:57d1a5d41b149a6f53efa2c075005a426dd5daeaaf0770a18d4a8d9b05a4268f
+size 39937759

--- a/Content/ThirdPerson/Inventory/BP_KeyPickupable1.uasset
+++ b/Content/ThirdPerson/Inventory/BP_KeyPickupable1.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:99f32eaa83ffb92e198b5f878301bd801ae6d681a66a83c520aed4e8c17f36b9
-size 44506
+oid sha256:af15623600aeb8fff0feaebf37491cb687c8f5fea3854a2c84f95008550abe25
+size 44522


### PR DESCRIPTION
There will be multiple keys but they unlock different areas of the map so they will need to be distinguishable and not stack on each other in the inventory. Seems to have also fixed that bug I was noticing.